### PR TITLE
Fix dead pilot bug in AR_Rappel_All_Cargo function.

### DIFF
--- a/addons/AR_AdvancedRappelling/functions/fn_advancedRappellingInit.sqf
+++ b/addons/AR_AdvancedRappelling/functions/fn_advancedRappellingInit.sqf
@@ -581,7 +581,7 @@ AR_Rappel_All_Cargo = {
 			[_vehicle, _positionASL] spawn {
 				params ["_vehicle","_positionASL"];
 				
-				while { _vehicle getVariable ["AR_Units_Rappelling",false] && alive _vehicle } do {
+				while { _vehicle getVariable ["AR_Units_Rappelling",false] && alive driver _vehicle} do {
 
 					_velocityMagatude = 5;
 					_distanceToPosition = ((getPosASL _vehicle) distance _positionASL);


### PR DESCRIPTION
I definitely like this add-on. [ Ares Mod - Achilles Expansion](https://forums.bistudio.com/topic/191113-ares-mod-achilles-expansion/) V.0.0.5 comes with a new waypoint that makes use of your function in the case Zeus has loaded Advanced Rappelling.

I tested your function on several occasions and observed a strange behavior:

If the pilot dies during the hovering phase, the helicopter does not crash, but spins in a strange fashion at its current position until the rappelling process is completed. Hence, I recommend checking for the pilot rather than the helicopter in the part that is associated with the hovering.
