### PR TITLE
Linux dedicated server fix

### DIFF
--- a/addons/AR_AdvancedRappelling/functions/fn_advancedRappellingInit.sqf
+++ b/addons/AR_AdvancedRappelling/functions/fn_advancedRappellingInit.sqf
@@ -618,10 +618,6 @@ AR_Enable_Rappelling_Animation_Client = {
 	if(local _player && !_globalExec) then {
 		[[_player],"AR_Enable_Rappelling_Animation"] call AR_RemoteExecServer;
 	};
-
-	if(_player != player) then {
-		_player enableSimulation false;
-	};
 	
 	if(call AR_Has_Addon_Animations_Installed) then {		
 		if([_player] call AR_Current_Weapon_Type_Selected == "HANDGUN") then {


### PR DESCRIPTION
I've created a extender mod for [antistati](https://steamcommunity.com/sharedfiles/filedetails/?id=3456362403)  to test fixes for Linux dedicated server situation

After some testing on Ubuntu Server 22.04, and no issues reported I think this should actually fix the issues with the mod

I personally don't have a Linux server, I "outsourced" testing to someone else

you don't need disable simulation for non-player entities, I've tested this on local host on windows and nothing changed, so this shouldn't affect any functionality